### PR TITLE
Fix parser performance.

### DIFF
--- a/src/main/java/no/ssb/avro/convert/csv/CsvParserFactory.java
+++ b/src/main/java/no/ssb/avro/convert/csv/CsvParserFactory.java
@@ -1,0 +1,78 @@
+package no.ssb.avro.convert.csv;
+
+import no.ssb.avro.convert.core.ValueInterceptor;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public class CsvParserFactory {
+    final CsvParserSettings parserSettings;
+    final com.univocity.parsers.csv.CsvParser internalCsvParser;
+    final ValueInterceptor valueInterceptor;
+
+    private CsvParserFactory(CsvParserSettings parserSettings, com.univocity.parsers.csv.CsvParser internalCsvParser, ValueInterceptor valueInterceptor) {
+        Objects.requireNonNull(parserSettings);
+        Objects.requireNonNull(internalCsvParser);
+        this.parserSettings = parserSettings;
+        this.internalCsvParser = internalCsvParser;
+        this.valueInterceptor = valueInterceptor;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private CsvParserSettings parserSettings = new CsvParserSettings();
+        private com.univocity.parsers.csv.CsvParser internalCsvParser;
+        private ValueInterceptor valueInterceptor;
+
+        public Builder withSettings(CsvParserSettings settings) {
+            if (settings == null) {
+                this.parserSettings = new CsvParserSettings();
+            } else {
+                this.parserSettings = settings;
+            }
+            return this;
+        }
+
+        public Builder withSettings(Map<String, Object> settings) {
+            parserSettings.configure(settings);
+            return this;
+        }
+
+        public Builder withValueInterceptor(ValueInterceptor valueInterceptor) {
+            this.valueInterceptor = valueInterceptor;
+            return this;
+        }
+
+        public CsvParserFactory build() {
+            internalCsvParser = new com.univocity.parsers.csv.CsvParser(parserSettings.getInternal());
+            return new CsvParserFactory(parserSettings, internalCsvParser, valueInterceptor);
+        }
+    }
+
+    public CsvParserSettings getSettings() {
+        return this.parserSettings;
+    }
+
+    public List<String> getHeaders() {
+        return Arrays.asList(this.internalCsvParser.getRecordMetadata().headers());
+    }
+
+    public String getDelimiter() {
+        return this.internalCsvParser.getDetectedFormat().getDelimiterString();
+    }
+
+    public CsvParser parserFor(byte[] csvData) {
+        return new CsvParser(parserSettings, internalCsvParser, valueInterceptor, new ByteArrayInputStream(csvData));
+    }
+
+    public CsvParser parserFor(InputStream inputStream) {
+        return new CsvParser(parserSettings, internalCsvParser, valueInterceptor, inputStream);
+    }
+}

--- a/src/main/java/no/ssb/avro/convert/csv/CsvToRecords.java
+++ b/src/main/java/no/ssb/avro/convert/csv/CsvToRecords.java
@@ -3,14 +3,11 @@ package no.ssb.avro.convert.csv;
 import no.ssb.avro.convert.core.DataElement;
 import no.ssb.avro.convert.core.SchemaAwareElement;
 import no.ssb.avro.convert.core.SchemaBuddy;
-import no.ssb.avro.convert.core.ValueInterceptor;
-import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Iterator;
-import java.util.Map;
 
 public class CsvToRecords implements AutoCloseable, Iterable<GenericRecord> {
 
@@ -18,23 +15,9 @@ public class CsvToRecords implements AutoCloseable, Iterable<GenericRecord> {
     private final SchemaBuddy schemaBuddy;
     private Callback callBack;
 
-    public CsvToRecords(InputStream inputStream, Schema schema) throws IOException {
-        this(inputStream, schema, (CsvParserSettings) null);
-    }
-
-    public CsvToRecords(InputStream inputStream, Schema schema, Map<String, Object> settings) throws IOException {
-        this.csvParser = CsvParser.builder().withSettings(settings).buildFor(inputStream);
-        this.schemaBuddy = SchemaBuddy.parse(schema);
-    }
-
-    public CsvToRecords(InputStream inputStream, Schema schema, CsvParserSettings settings) throws IOException {
-        this.csvParser = CsvParser.builder().withSettings(settings).buildFor(inputStream);
-        this.schemaBuddy = SchemaBuddy.parse(schema);
-    }
-
-    public CsvToRecords withValueInterceptor(ValueInterceptor valueInterceptor) {
-        csvParser.withValueInterceptor(valueInterceptor);
-        return this;
+    public CsvToRecords(CsvParserFactory csvParserFactory, InputStream inputStream, SchemaBuddy schemaBuddy) {
+        this.csvParser = csvParserFactory.parserFor(inputStream);
+        this.schemaBuddy = schemaBuddy;
     }
 
     public CsvToRecords withCallBack(Callback callBack) {

--- a/src/test/java/no/ssb/avro/convert/csv/CsvToRecordsTest.java
+++ b/src/test/java/no/ssb/avro/convert/csv/CsvToRecordsTest.java
@@ -1,5 +1,6 @@
 package no.ssb.avro.convert.csv;
 
+import no.ssb.avro.convert.core.SchemaBuddy;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 import org.junit.jupiter.api.Test;
@@ -33,7 +34,9 @@ class CsvToRecordsTest {
         InputStream csvInputStream = data(scenario + ".csv");
         Schema schema = schema(scenario + ".avsc");
         List<GenericRecord> records = new ArrayList<>();
-        try (CsvToRecords csvToRecords = new CsvToRecords(csvInputStream, schema)) {
+        CsvParserFactory factory = CsvParserFactory.builder()
+                .build();
+        try (CsvToRecords csvToRecords = new CsvToRecords(factory, csvInputStream, SchemaBuddy.parse(schema))) {
             csvToRecords.forEach(records::add);
         }
 
@@ -46,13 +49,15 @@ class CsvToRecordsTest {
         Schema schema = schema("simple.avsc");
         List<GenericRecord> records = new ArrayList<>();
 
-        try (CsvToRecords csvToRecords = new CsvToRecords(csvInputStream, schema)
-          .withValueInterceptor((field, value) -> {
-            if ("someString".equals(field.getName()) && "Captain Joe".equals(value)) {
-                return "substituted value";
-            }
-            return value;
-        })) {
+        CsvParserFactory factory = CsvParserFactory.builder()
+                .withValueInterceptor((field, value) -> {
+                    if ("someString".equals(field.getName()) && "Captain Joe".equals(value)) {
+                        return "substituted value";
+                    }
+                    return value;
+                })
+                .build();
+        try (CsvToRecords csvToRecords = new CsvToRecords(factory, csvInputStream, SchemaBuddy.parse(schema))) {
             csvToRecords.forEach(records::add);
         }
 
@@ -71,7 +76,9 @@ class CsvToRecordsTest {
           "a_column-with-$pecicialName!", "renamedCol2Name"
         ));
 
-        try (CsvToRecords csvToRecords = new CsvToRecords(csvInputStream, schema, csvParserSettings)) {
+        CsvParserFactory factory = CsvParserFactory.builder()
+                .build();
+        try (CsvToRecords csvToRecords = new CsvToRecords(factory, csvInputStream, SchemaBuddy.parse(schema))) {
             csvToRecords.forEach(records::add);
         }
 
@@ -92,7 +99,10 @@ class CsvToRecordsTest {
           "renamedCol2Name",
           "renamedCol3Name"));
 
-        try (CsvToRecords csvToRecords = new CsvToRecords(csvInputStream, schema, csvParserSettings)) {
+        CsvParserFactory factory = CsvParserFactory.builder()
+          .withSettings(csvParserSettings)
+          .build();
+        try (CsvToRecords csvToRecords = new CsvToRecords(factory, csvInputStream, SchemaBuddy.parse(schema))) {
             csvToRecords.forEach(records::add);
         }
 


### PR DESCRIPTION
The cost of initializing the univocity parser is much higher than parsing one small csv line. Thus, for use-cases with many tiny csv fragments (like rawdata streams) we need to re-use the parser across data-fragments to achieve acceptable peformance. 

This change allows clients to initialize factory once and then to re-use the factory across input-streams.